### PR TITLE
Update kscreenlockerrc

### DIFF
--- a/usr/share/netrunner-default-settings/plasma5-profile/kscreenlockerrc
+++ b/usr/share/netrunner-default-settings/plasma5-profile/kscreenlockerrc
@@ -1,5 +1,6 @@
 [Daemon]
 Timeout=0
+Autolock=false
 
 [Greeter]
 Theme=org.kde.breeze.desktop


### PR DESCRIPTION
Upstream added new config option for this so it never worked in first session. Though upstream provided new kconf_update script so was fixed on second boot
